### PR TITLE
Fix boost::format when used with logs

### DIFF
--- a/lib/interrupt_emitter_impl.cc
+++ b/lib/interrupt_emitter_impl.cc
@@ -15,6 +15,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/timing_utils/constants.h>
 #include <cmath>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace timing_utils {
@@ -163,8 +164,8 @@ void interrupt_emitter_impl<T>::handle_set_time(pmt::pmt_t time_pmt)
     if (wait_time < 0) {
         if (d_drop_late) {
             GR_LOG_DEBUG(this->d_logger,
-                         boost::format("Dropping late interrupt request: %0.2f") %
-                             wait_time);
+                         str(boost::format("Dropping late interrupt request: %0.2f") %
+                             wait_time));
         } else {
             // Interrupt right now
             if (debug)

--- a/lib/system_time_diff_impl.cc
+++ b/lib/system_time_diff_impl.cc
@@ -13,6 +13,7 @@
 
 #include "system_time_diff_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace timing_utils {

--- a/lib/tag_uhd_offset_impl.cc
+++ b/lib/tag_uhd_offset_impl.cc
@@ -13,6 +13,7 @@
 
 #include "tag_uhd_offset_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace timing_utils {
@@ -81,9 +82,9 @@ void tag_uhd_offset_impl<T>::update_time_tag(uint64_t offset)
     double delta = ((offset - d_time_tag_offset) / d_rate);
     if (delta < 0) {
         GR_LOG_ERROR(this->d_logger,
-                     boost::format("can't go back in time...updating time tag failed "
+                     str(boost::format("can't go back in time...updating time tag failed "
                                    "(requested delta = %fs)") %
-                         delta);
+                         delta));
         return;
     }
     d_time_tag_frac_sec += delta;

--- a/lib/time_delta_impl.cc
+++ b/lib/time_delta_impl.cc
@@ -13,6 +13,7 @@
 
 #include "time_delta_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace timing_utils {
@@ -55,8 +56,8 @@ bool time_delta_impl::stop()
 
     GR_LOG_INFO(
         d_logger,
-        boost::format("WALL_CLOCK_TIME_DEBUG (%s): Mean = %0.6f ms, Var = %0.6f ms") %
-            d_name % mean % var);
+        str(boost::format("WALL_CLOCK_TIME_DEBUG (%s): Mean = %0.6f ms, Var = %0.6f ms") %
+            d_name % mean % var));
     return true;
 }
 
@@ -83,14 +84,14 @@ void time_delta_impl::handle_pdu(pmt::pmt_t pdu)
     pmt::pmt_t wct_pmt = pmt::dict_ref(meta, d_time_key, pmt::PMT_NIL);
     if (!pmt::is_real(wct_pmt)) {
         GR_LOG_DEBUG(d_logger,
-                     boost::format("PDU received with no wall clock time at %f") % t_now);
+                     str(boost::format("PDU received with no wall clock time at %f") % t_now));
     } else {
         double pdu_time = pmt::to_double(wct_pmt);
         double time_delta = (t_now - pdu_time) * 1000.0;
         GR_LOG_DEBUG(
             d_logger,
-            boost::format("%s PDU received at %f with time delta %f milliseconds") %
-                d_name % t_now % time_delta);
+            str(boost::format("%s PDU received at %f with time delta %f milliseconds") %
+                d_name % t_now % time_delta));
 
         // add to metadata
         meta = pmt::dict_add(meta, d_delta_key, pmt::from_double(time_delta));

--- a/lib/timed_freq_xlating_fir_impl.cc
+++ b/lib/timed_freq_xlating_fir_impl.cc
@@ -15,6 +15,7 @@
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 #include <stdexcept>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace timing_utils {
@@ -283,9 +284,9 @@ int timed_freq_xlating_fir_impl<I, O, T>::work(int noutput_items,
                         pmt::make_dict(), PMTCONSTSTR__freq(), tags[0].value));
                     GR_LOG_INFO(
                         this->d_logger,
-                        boost::format("Synchronously setting freq xlator to %f Hz with a "
+                        str(boost::format("Synchronously setting freq xlator to %f Hz with a "
                                       "phase of %f radians at sample %d") %
-                            new_freq % new_phase % tags[0].offset);
+                            new_freq % new_phase % tags[0].offset));
                     d_tag_freq_applied = true;
                 } else if (pmt::is_real(tags[0].value)) {
                     double new_freq = pmt::to_double(tags[0].value);
@@ -295,9 +296,9 @@ int timed_freq_xlating_fir_impl<I, O, T>::work(int noutput_items,
                             pmt::make_dict(), PMTCONSTSTR__freq(), tags[0].value));
                         GR_LOG_INFO(
                             this->d_logger,
-                            boost::format(
+                            str(boost::format(
                                 "Synchronously setting freq xlator to %f at sample %d") %
-                                new_freq % tags[0].offset);
+                                new_freq % tags[0].offset));
                     }
                     d_tag_freq_applied = true;
                 } else {


### PR DESCRIPTION
Two problems have occurred in building this with the latest 3.10. First, boost::format needs the #include <boost/format.hpp> header. Second, there are problems when trying to use boost::format with the version of format that is used with spdlog.  This resolves both issues.