### PR TITLE
Remove dependency on gr-sandia_utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,6 @@ find_package(Doxygen)
 # Dependencies
 ########################################################################
 find_package(gnuradio-pdu_utils "3.10.0" REQUIRED)
-find_package(gnuradio-sandia_utils "3.10" REQUIRED)
 
 ########################################################################
 # Setup doxygen option


### PR DESCRIPTION
The module no longer depends on gr-sandia_utils to build, so this removes the dependency from the CMakeLists.txt file.